### PR TITLE
add option to fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.ppk
 *.efi
 *.kpxe
-netboot-services/cachingServerFetcher/caching-server.ipxe

--- a/netboot-services/http/Dockerfile
+++ b/netboot-services/http/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.21.0-alpine
+FROM nginx:1.23.4-alpine
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/netboot-services/ipxeMenuGenerator/README.md
+++ b/netboot-services/ipxeMenuGenerator/README.md
@@ -2,6 +2,21 @@
 
 This container consumes the `NETBOOT_SERVER_IP` that is passed via an environment variable and produces an IPXE menu. It takes the templates and generates the menu based on the files available in the `assets` folder. It checks for a `dev` and `prod` folder and generates the menu based on the files in there. The menu is then written to the `config/menus` folder.
 
+Based on the available variables passed in [ipxe-menu-generator.env](./ipxe-menu-generator.env), the following workflow will be impacted.
+
+## IPXE Workflow
+
+The IPXE workflow is as follows:
+
+1. The next-server defined on the DHCP server points to either a local netboot server per location or the azure netboot server
+2. The netboot server serves the IPXE binary (`undionly.kpxe`, `ipxe32.efi`, `ipxe64.efi`), which points to the `menu.ipxe` which is dyanmically generated on each netboot server.
+3. If the `next-server` equals the value of the azure netboot server, it checks the availability of faster netboot server which is exposed through a reverse proxy. If the reverse proxy is available, the HTTP basic auth details will be created and the correct variables will be set (`http-protocol`, `url`, `basicAuth`).
+4. If the check on the faster netboot server fails, a check will be made, if a storage account in azure, which holds the necessary files, is available. If it is available, the correct variables will be set (`http-protocol`, `url`, `sas_token`).
+5. If none of the above is true, we will use the local netboot server as a primary source.
+6. Based on the available variables, the menu will be generated and served to the client.
+
+Note: `sas_token` and `basicAuth` are mutually exclusive. If one variable is not set, the IPXE menu generator will not parse the unused variable.
+
 ## MAC specific booting
 
 The MAC specific booting can be done in IPXE using `chain --autofree tftp://${next-server}/MAC-${mac:hexraw}.ipxe`. Currently we do not make use of this feature. Make sure to also check the file permissions of the .ipxe file.

--- a/netboot-services/ipxeMenuGenerator/advancedmenu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/advancedmenu.ipxe.j2
@@ -16,8 +16,6 @@ item --gap Development:
 {% for file in dev %}
 item thinclient-{{ file.imageName }} ${sp} {{ file.imageName }}
 {% endfor %}
-item --gap Cachingserver:
-item thinclient-netboot-caching-server.squashfs ${sp} netboot-caching-server
 item --gap Tools:
 item reset_windows ${sp} Notebook Wipe
 item public-netbootxyz ${sp} Public netboot.xyz ||
@@ -68,11 +66,10 @@ chain http://boot.netboot.xyz/ipxe/netboot.xyz-snponly.efi
 
 {% for file in prod %}
 :thinclient-{{ file.imageName }}
-set squash_url http://${next-server}/prod/{{ file.imageName }}.squashfs
-set kernel_url http://${next-server}/kernels/{{ file.kernelVersion }}/
+set squash_url ${http-protocol}://${basicAuth}${url}/prod/{{ file.imageName }}.squashfs${sas_token}
+set kernel_url ${http-protocol}://${basicAuth}${url}/kernels/{{ file.kernelVersion }}/
 goto startboot
 {% endfor %}
-
 
 ######################
 # Development-Images #
@@ -80,28 +77,19 @@ goto startboot
 
 {% for file in dev %}
 :thinclient-{{ file.imageName }}
-set squash_url http://${next-server}/dev/{{ file.imageName }}.squashfs
-set kernel_url http://${next-server}/kernels/{{ file.kernelVersion }}/
+set squash_url ${http-protocol}://${basicAuth}${url}/dev/{{ file.imageName }}.squashfs${sas_token}
+set kernel_url ${http-protocol}://${basicAuth}${url}/kernels/{{ file.kernelVersion }}/
 goto startboot-dev
 {% endfor %}
 
-######################
-# Cachingserver-Images #
-######################
-:thinclient-netboot-caching-server.squashfs
-set next-server {{ netbootServerIP }}
-set squash_url http://${next-server}/caching-server/casper/netboot-caching-server.squashfs
-set kernel_url http://${next-server}/kernels/5.11.0-16-generic/
-
-
 :startboot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd locale=${language} ${cmdline} quiet splash
-initrd ${kernel_url}initrd
+kernel ${kernel_url}vmlinuz${sas_token} ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd locale=${language} ${cmdline} quiet splash
+initrd ${kernel_url}initrd${sas_token}
 boot
 
 :startboot-dev
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd locale=${language} ${cmdline}
-initrd ${kernel_url}initrd
+kernel ${kernel_url}vmlinuz${sas_token} ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd locale=${language} ${cmdline}
+initrd ${kernel_url}initrd${sas_token}
 boot

--- a/netboot-services/ipxeMenuGenerator/ipxe-menu-generator.env
+++ b/netboot-services/ipxeMenuGenerator/ipxe-menu-generator.env
@@ -1,6 +1,7 @@
 NETBOOT_SERVER_IP="IP of the server the TFTP server is running on"
 AZURE_NETBOOT_SERVER_IP="IP of the Azure Netboot Server"
 AZURE_SYNC_SAS_TOKEN="SAS Token for fallback on Storage Account"
+AZURE_SYNC_BLOB_URL=https://insert-blob-name-here.blob.core.windows.net
 ONPREM_NETBOOT_SERVER_IP="IP of the OnPrem Netboot Server which is exposed"
 HTTP_AUTH_USER="User for http-basic-auth"
 HTTP_AUTH_PASSWORD="Password for http-basic-auth"

--- a/netboot-services/ipxeMenuGenerator/ipxe-menu-generator.env
+++ b/netboot-services/ipxeMenuGenerator/ipxe-menu-generator.env
@@ -2,6 +2,6 @@ NETBOOT_SERVER_IP="IP of the server the TFTP server is running on"
 AZURE_NETBOOT_SERVER_IP="IP of the Azure Netboot Server"
 AZURE_SYNC_SAS_TOKEN="SAS Token for fallback on Storage Account"
 AZURE_SYNC_BLOB_URL=https://insert-blob-name-here.blob.core.windows.net
-ONPREM_NETBOOT_SERVER_IP="IP of the OnPrem Netboot Server which is exposed"
+ONPREM_NETBOOT_SERVER="On-premise netboot Server which is exposed through a reverse proxy"
 HTTP_AUTH_USER="User for http-basic-auth"
 HTTP_AUTH_PASSWORD="Password for http-basic-auth"

--- a/netboot-services/ipxeMenuGenerator/ipxe-menu-generator.env
+++ b/netboot-services/ipxeMenuGenerator/ipxe-menu-generator.env
@@ -1,1 +1,6 @@
 NETBOOT_SERVER_IP="IP of the server the TFTP server is running on"
+AZURE_NETBOOT_SERVER_IP="IP of the Azure Netboot Server"
+AZURE_SYNC_SAS_TOKEN="SAS Token for fallback on Storage Account"
+ONPREM_NETBOOT_SERVER_IP="IP of the OnPrem Netboot Server which is exposed"
+HTTP_AUTH_USER="User for http-basic-auth"
+HTTP_AUTH_PASSWORD="Password for http-basic-auth"

--- a/netboot-services/ipxeMenuGenerator/main.go
+++ b/netboot-services/ipxeMenuGenerator/main.go
@@ -48,6 +48,11 @@ func main() {
 			log.Error("AZURE_SYNC_SAS_TOKEN not set")
 		}
 
+		azureBlobstorageURL := os.Getenv("AZURE_SYNC_BLOB_URL")
+		if azureBlobstorageURL == "" {
+			log.Error("AZURE_SYNC_BLOB_URL not set")
+		}
+
 		httpAuthUser := os.Getenv("HTTP_AUTH_USER")
 		if httpAuthUser == "" {
 			log.Fatal("HTTP_AUTH_USER not set")
@@ -58,9 +63,9 @@ func main() {
 			log.Fatal("HTTP_AUTH_PASSWORD not set")
 		}
 
-		renderMenuIpxe("menu.ipxe.j2", ProdFolder, netbootServerIP, azureNetbootServerIP, onpremExposedNetbootServer, azureBlobstorageSASToken, httpAuthUser, httpAuthPassword)
+		renderMenuIpxe("menu.ipxe.j2", ProdFolder, netbootServerIP, azureNetbootServerIP, onpremExposedNetbootServer, azureBlobstorageURL, azureBlobstorageSASToken, httpAuthUser, httpAuthPassword)
 
-		err := renderAdvancedMenu("advancedmenu.ipxe.j2", netbootServerIP, azureNetbootServerIP, onpremExposedNetbootServer, azureBlobstorageSASToken, httpAuthUser, httpAuthPassword)
+		err := renderAdvancedMenu("advancedmenu.ipxe.j2", netbootServerIP, azureNetbootServerIP, onpremExposedNetbootServer, azureBlobstorageURL, azureBlobstorageSASToken, httpAuthUser, httpAuthPassword)
 		if err != nil {
 			log.Error(err)
 		}
@@ -136,7 +141,7 @@ func getMatchingKernelVersion(folderName string, imageName string) (string, erro
 	return version.KernelVersion, err
 }
 
-func renderMenuIpxe(filename string, folderName string, netbootServerIP string, azureNetbootServerIP string, onpremExposedNetbootServer string, azureBlobstorageSASToken string, httpAuthUser string, httpAuthPassword string) {
+func renderMenuIpxe(filename string, folderName string, netbootServerIP string, azureNetbootServerIP string, onpremExposedNetbootServer string, azureBlobstorageURL string, azureBlobstorageSASToken string, httpAuthUser string, httpAuthPassword string) {
 	mostRecentSquashfsImageName, err := getMostRecentSquashfsImage(folderName)
 	if err != nil {
 		log.Error(err)
@@ -153,6 +158,7 @@ func renderMenuIpxe(filename string, folderName string, netbootServerIP string, 
 			jinja2.WithGlobal("azureNetbootServerIP", azureNetbootServerIP),
 			jinja2.WithGlobal("onpremExposedNetbootServer", onpremExposedNetbootServer),
 			jinja2.WithGlobal("azureBlobstorageSASToken", azureBlobstorageSASToken),
+			jinja2.WithGlobal("azureBlobstorageURL", azureBlobstorageURL),
 			jinja2.WithGlobal("httpAuthUser", httpAuthUser),
 			jinja2.WithGlobal("httpAuthPassword", httpAuthPassword),
 			jinja2.WithGlobal("imageName", mostRecentSquashfsImageName),
@@ -220,7 +226,7 @@ func getImages(folderName string) []image {
 	return images
 }
 
-func renderAdvancedMenu(filename string, netbootServerIP string, azureNetbootServerIP string, onpremExposedNetbootServer string, azureBlobstorageSASToken string, httpAuthUser string, httpAuthPassword string) error {
+func renderAdvancedMenu(filename string, netbootServerIP string, azureNetbootServerIP string, onpremExposedNetbootServer string, azureBlobstorageURL string, azureBlobstorageSASToken string, httpAuthUser string, httpAuthPassword string) error {
 	prodImages := getProdImages()
 	devImages := getDevImages()
 	j2, err := jinja2.NewJinja2("advancedmenu.ipxe", 1,
@@ -228,6 +234,7 @@ func renderAdvancedMenu(filename string, netbootServerIP string, azureNetbootSer
 		jinja2.WithGlobal("azureNetbootServerIP", azureNetbootServerIP),
 		jinja2.WithGlobal("onpremExposedNetbootServer", onpremExposedNetbootServer),
 		jinja2.WithGlobal("azureBlobstorageSASToken", azureBlobstorageSASToken),
+		jinja2.WithGlobal("azureBlobstorageURL", azureBlobstorageURL),
 		jinja2.WithGlobal("httpAuthUser", httpAuthUser),
 		jinja2.WithGlobal("httpAuthPassword", httpAuthPassword),
 		jinja2.WithGlobal("prod", prodImages),

--- a/netboot-services/ipxeMenuGenerator/main.go
+++ b/netboot-services/ipxeMenuGenerator/main.go
@@ -45,12 +45,12 @@ func main() {
 
 		azureBlobstorageSASToken := os.Getenv("AZURE_SYNC_SAS_TOKEN")
 		if azureBlobstorageSASToken == "" {
-			log.Error("AZURE_SYNC_SAS_TOKEN not set")
+			log.Fatal("AZURE_SYNC_SAS_TOKEN not set")
 		}
 
 		azureBlobstorageURL := os.Getenv("AZURE_SYNC_BLOB_URL")
 		if azureBlobstorageURL == "" {
-			log.Error("AZURE_SYNC_BLOB_URL not set")
+			log.Fatal("AZURE_SYNC_BLOB_URL not set")
 		}
 
 		httpAuthUser := os.Getenv("HTTP_AUTH_USER")

--- a/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
@@ -5,18 +5,18 @@
 # Language-Detection: Set different languages based on the default gateway IP address
 :language
 # Lausanne
-iseq ${netX/gateway} 172.20.72.1 && set language fr_CH && goto register_basic_auth ||
+iseq ${netX/gateway} 172.20.72.1 && set language fr_CH && goto check_boot_from_azure ||
 # Genf
-iseq ${netX/gateway} 172.20.56.1 && set language fr_CH && goto register_basic_auth ||
+iseq ${netX/gateway} 172.20.56.1 && set language fr_CH && goto check_boot_from_azure ||
 # Krefeld
-iseq ${netX/gateway} 172.22.32.1 && set language de_DE && goto register_basic_auth ||
+iseq ${netX/gateway} 172.22.32.1 && set language de_DE && goto check_boot_from_azure ||
 # Odilia
-iseq ${netX/gateway} 172.22.224.1 && set language de_DE && goto register_basic_auth ||
+iseq ${netX/gateway} 172.22.224.1 && set language de_DE && goto check_boot_from_azure ||
 # Fallback (when no condition above triggers to set next-server)
 set language de_CH
 
 :check_boot_from_azure
-iseq ${next-server} {{ azureNetbootServerIP }} && goto :register_basic_auth ||
+iseq ${next-server} {{ azureNetbootServerIP }} && goto register_basic_auth ||
 # if nothing applies, boot from local network
 set http-protocol http && set url ${next-server} && goto initial_menu ||
 
@@ -29,7 +29,7 @@ imgfetch https://${httpAuthUser}:${httpAuthPassword}@{{ onpremExposedNetbootServ
 goto check_if_storage_account_is_reachable ||
 
 :check_if_storage_account_is_reachable
-imgfetch {{ azureBlobstorageURL }}/kernels/latest-kernel-version.json{{ azureBlobstorageSASToken }} &&  goto set_azure_storageaccount ||
+imgfetch https://{{ azureBlobstorageURL }}/kernels/latest-kernel-version.json{{ azureBlobstorageSASToken }} &&  goto set_azure_storageaccount ||
 set http-protocol http && goto initial_menu ||
 
 :set_onprem_netbootserver

--- a/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
@@ -21,18 +21,18 @@ iseq ${next-server} {{ azureNetbootServerIP }} && goto register_basic_auth ||
 set http-protocol http && set url ${next-server} && goto initial_menu ||
 
 :register_basic_auth
-set httpAuthUser {{ httpAuthUser }} && set httpAuthPassword {{ httpAuthPassword }} && goto check_if_onprem_netbootserver_is_reachable || 
+set httpAuthUser {{ httpAuthUser }} && set httpAuthPassword {{ httpAuthPassword }} && goto check_if_onprem_exposed_netboot_is_reachable || 
 goto check_if_storage_account_is_reachable ||
 
-:check_if_onprem_netbootserver_is_reachable
-imgfetch https://${httpAuthUser}:${httpAuthPassword}@{{ onpremExposedNetbootServer }}:8443/kernels/latest-kernel-version.json && goto set_onprem_netbootserver ||
+:check_if_onprem_exposed_netboot_is_reachable
+imgfetch https://${httpAuthUser}:${httpAuthPassword}@{{ onpremExposedNetbootServer }}:8443/kernels/latest-kernel-version.json && goto set_onprem_exposed_netboot ||
 goto check_if_storage_account_is_reachable ||
 
 :check_if_storage_account_is_reachable
 imgfetch https://{{ azureBlobstorageURL }}/kernels/latest-kernel-version.json{{ azureBlobstorageSASToken }} &&  goto set_azure_storageaccount ||
 set http-protocol http && goto initial_menu ||
 
-:set_onprem_netbootserver
+:set_onprem_exposed_netboot
 set http-protocol https && set url {{ onpremExposedNetbootServer }}:8443 && set basicAuth {{ httpAuthUser }}:{{ httpAuthPassword }}@ && goto initial_menu ||
 goto initial_menu ||
 

--- a/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
@@ -29,7 +29,7 @@ imgfetch https://${httpAuthUser}:${httpAuthPassword}@{{ onpremExposedNetbootServ
 goto check_if_storage_account_is_reachable ||
 
 :check_if_storage_account_is_reachable
-imgfetch https://thinclientsimgstore.blob.core.windows.net/kernels/latest-kernel-version.json{{ azureBlobstorageSASToken }} &&  goto set_azure_storageaccount ||
+imgfetch {{ azureBlobstorageURL }}/kernels/latest-kernel-version.json{{ azureBlobstorageSASToken }} &&  goto set_azure_storageaccount ||
 set http-protocol http && goto initial_menu ||
 
 :set_onprem_netbootserver
@@ -37,7 +37,7 @@ set http-protocol https && set url {{ onpremExposedNetbootServer }}:8443 && set 
 goto initial_menu ||
 
 :set_azure_storageaccount
-set http-protocol https && set url thinclientsimgstore.blob.core.windows.net && set sas_token {{ azureBlobstorageSASToken }} && goto initial_menu ||
+set http-protocol https && set url {{ azureBlobstorageURL }} && set sas_token {{ azureBlobstorageSASToken }} && goto initial_menu ||
 
 :macboot
 chain --autofree tftp://{{ netbootServerIP }}/ipxe/MAC-${mac:hexraw}.ipxe || echo Custom boot by MAC not found, going to menu...

--- a/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
@@ -22,7 +22,7 @@ set http-protocol http && set url ${next-server} && goto initial_menu ||
 
 :register_basic_auth
 set httpAuthUser {{ httpAuthUser }} && set httpAuthPassword {{ httpAuthPassword }} && goto check_if_onprem_netbootserver_is_reachable || 
-goto check_if_onprem_netbootserver_is_reachable ||
+goto check_if_storage_account_is_reachable ||
 
 :check_if_onprem_netbootserver_is_reachable
 imgfetch https://${httpAuthUser}:${httpAuthPassword}@{{ onpremExposedNetbootServer }}:8443/kernels/latest-kernel-version.json && goto set_onprem_netbootserver ||
@@ -51,7 +51,6 @@ item --gap Erweitert:
 item advanced ${sp} Erweiterte Bootoptionen
 item reboot ${sp} Neustart
 item --gap Aktuell gesetzter Bootserver: ${next-server}
-item --gap Aktuell gesetzter Fileserver: {{ onpremExposedNetbootServer }}
 item --gap Aktuell gesetzte Sprache: ${language}
 choose --timeout 10000 initial_choice || goto start
 goto ${initial_choice}

--- a/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
@@ -5,15 +5,39 @@
 # Language-Detection: Set different languages based on the default gateway IP address
 :language
 # Lausanne
-iseq ${netX/gateway} 172.20.72.1 && set language fr_CH && goto initial_menu ||
+iseq ${netX/gateway} 172.20.72.1 && set language fr_CH && goto register_basic_auth ||
 # Genf
-iseq ${netX/gateway} 172.20.56.1 && set language fr_CH && goto initial_menu ||
+iseq ${netX/gateway} 172.20.56.1 && set language fr_CH && goto register_basic_auth ||
 # Krefeld
-iseq ${netX/gateway} 172.22.32.1 && set language de_DE && goto initial_menu ||
+iseq ${netX/gateway} 172.22.32.1 && set language de_DE && goto register_basic_auth ||
 # Odilia
-iseq ${netX/gateway} 172.22.224.1 && set language de_DE && goto initial_menu ||
+iseq ${netX/gateway} 172.22.224.1 && set language de_DE && goto register_basic_auth ||
 # Fallback (when no condition above triggers to set next-server)
 set language de_CH
+
+:check_boot_from_azure
+iseq ${next-server} {{ azureNetbootServerIP }} && goto :register_basic_auth ||
+# if nothing applies, boot from local network
+set http-protocol http && set url ${next-server} && goto initial_menu ||
+
+:register_basic_auth
+set httpAuthUser {{ httpAuthUser }} && set httpAuthPassword {{ httpAuthPassword }} && goto check_if_onprem_netbootserver_is_reachable || 
+goto check_if_onprem_netbootserver_is_reachable ||
+
+:check_if_onprem_netbootserver_is_reachable
+imgfetch https://${httpAuthUser}:${httpAuthPassword}@{{ onpremExposedNetbootServer }}:8443/kernels/latest-kernel-version.json && goto set_onprem_netbootserver ||
+goto check_if_storage_account_is_reachable ||
+
+:check_if_storage_account_is_reachable
+imgfetch https://thinclientsimgstore.blob.core.windows.net/kernels/latest-kernel-version.json{{ azureBlobstorageSASToken }} &&  goto set_azure_storageaccount ||
+set http-protocol http && goto initial_menu ||
+
+:set_onprem_netbootserver
+set http-protocol https && set url {{ onpremExposedNetbootServer }}:8443 && set basicAuth {{ httpAuthUser }}:{{ httpAuthPassword }}@ && goto initial_menu ||
+goto initial_menu ||
+
+:set_azure_storageaccount
+set http-protocol https && set url thinclientsimgstore.blob.core.windows.net && set sas_token {{ azureBlobstorageSASToken }} && goto initial_menu ||
 
 :macboot
 chain --autofree tftp://{{ netbootServerIP }}/ipxe/MAC-${mac:hexraw}.ipxe || echo Custom boot by MAC not found, going to menu...
@@ -27,19 +51,20 @@ item --gap Erweitert:
 item advanced ${sp} Erweiterte Bootoptionen
 item reboot ${sp} Neustart
 item --gap Aktuell gesetzter Bootserver: ${next-server}
+item --gap Aktuell gesetzter Fileserver: {{ onpremExposedNetbootServer }}
 item --gap Aktuell gesetzte Sprache: ${language}
 choose --timeout 10000 initial_choice || goto start
 goto ${initial_choice}
 
 # Bootconfigurtion for our netboot-OS
 :dg-thinclient-prod
-set squash_url http://{{ netbootServerIP }}/prod/{{ imageName }}.squashfs
-set kernel_url http://{{ netbootServerIP }}/kernels/{{ kernelFolderName }}/
+set squash_url ${http-protocol}://${basicAuth}${url}/prod/{{ imageName }}.squashfs${sas_token}
+set kernel_url ${http-protocol}://${basicAuth}${url}/kernels/{{ kernelFolderName }}/
 
 :startboot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd locale=${language} ${cmdline}
-initrd ${kernel_url}initrd
+kernel ${kernel_url}vmlinuz${sas_token} ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd locale=${language} ${cmdline}
+initrd ${kernel_url}initrd${sas_token}
 boot
 
 # Chaining the advanced menu.

--- a/netboot-services/tftp/Dockerfile
+++ b/netboot-services/tftp/Dockerfile
@@ -1,16 +1,23 @@
 FROM alpine:3.18 as bootfiles
-RUN apk add --no-cache bash gcc binutils make perl xz-libs xz-dev mtools git libc-dev
+RUN apk add --no-cache bash gcc binutils make perl xz-libs xz-dev mtools git libc-dev curl openssl coreutils
 WORKDIR /build
 # Clone iPXE
 RUN git clone git://git.ipxe.org/ipxe.git
 RUN sed -i 's/#undef\tDOWNLOAD_PROTO_HTTPS/#define\ DOWNLOAD_PROTO_HTTPS/' ipxe/src/config/general.h
+RUN sed -i 's/\/\/#define PING_CMD/#define PING_CMD/' ipxe/src/config/general.h
+RUN sed -i 's/\/\/#define NSLOOKUP_CMD/#define NSLOOKUP_CMD/' ipxe/src/config/general.h
+RUN export CERT=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem && export TRUST=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem
+RUN curl -s http://ca.ipxe.org/ca.crt > ipxe/src/ca.pem 
+RUN curl -s https://letsencrypt.org/certs/isrgrootx1.pem > ipxe/src/isrgrootx1.pem
+RUN curl -s https://letsencrypt.org/certs/lets-encrypt-r3.pem > ipxe/src/lets-encrypt-r3.pem
+
 # Include custom logic
 COPY custom.ipxe ipxe/src/custom.ipxe
 # Run the builds
 # Note: We're using snponly to retain the original UEFI-drivers and thus improving reliability and reducing the size of the bootloader.
-RUN cd ipxe/src && make bin/undionly.kpxe EMBED=custom.ipxe && \
-make bin-i386-efi/snponly.efi EMBED=custom.ipxe && \
-make bin-x86_64-efi/snponly.efi EMBED=custom.ipxe
+RUN cd ipxe/src && make bin/undionly.kpxe EMBED=custom.ipxe CERT=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem TRUST=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem && \
+make bin-i386-efi/snponly.efi EMBED=custom.ipxe CERT=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem TRUST=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem  && \
+make bin-x86_64-efi/snponly.efi EMBED=custom.ipxe CERT=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem TRUST=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem 
 
 FROM alpine:3.18
 

--- a/netboot-services/tftp/Dockerfile
+++ b/netboot-services/tftp/Dockerfile
@@ -6,6 +6,8 @@ RUN git clone git://git.ipxe.org/ipxe.git
 RUN sed -i 's/#undef\tDOWNLOAD_PROTO_HTTPS/#define\ DOWNLOAD_PROTO_HTTPS/' ipxe/src/config/general.h
 RUN sed -i 's/\/\/#define PING_CMD/#define PING_CMD/' ipxe/src/config/general.h
 RUN sed -i 's/\/\/#define NSLOOKUP_CMD/#define NSLOOKUP_CMD/' ipxe/src/config/general.h
+# Workaround for fetching data from servers with a Let's Encrypt certificate.
+# https://github.com/ipxe/ipxe/issues/606 - Certificate validation fails when the last certificate of the chain is signed by an expired CA (DST Root CA X3)
 RUN export CERT=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem && export TRUST=ca.pem,isrgrootx1.pem,lets-encrypt-r3.pem
 RUN curl -s http://ca.ipxe.org/ca.crt > ipxe/src/ca.pem 
 RUN curl -s https://letsencrypt.org/certs/isrgrootx1.pem > ipxe/src/isrgrootx1.pem


### PR DESCRIPTION
This PR enables clients that boot from the azure server, to first boot from our own exposed server and then as fallback, use blobstorage.