### PR TITLE
Adjust conditional IP for Odilia

### DIFF
--- a/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
@@ -11,7 +11,7 @@ iseq ${netX/gateway} 172.20.56.1 && set language fr_CH && goto check_boot_from_a
 # Krefeld
 iseq ${netX/gateway} 172.22.32.1 && set language de_DE && goto check_boot_from_azure ||
 # Odilia
-iseq ${netX/gateway} 172.22.224.1 && set language de_DE && goto check_boot_from_azure ||
+iseq ${netX/gateway} 172.22.240.1 && set language de_DE && goto check_boot_from_azure ||
 # Fallback (when no condition above triggers to set next-server)
 set language de_CH
 


### PR DESCRIPTION
Make sure, the thinclients boot with the german keyboard layout conditionally using the new netboot IP.