### PR TITLE
Remove obsolete docker-compose version attribute

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   netboot-tftp:
     image: dgpublicimagesprod.azurecr.io/planetexpress/netboot-tftp:latest


### PR DESCRIPTION
## Summary
- Remove obsolete `version` attribute from docker-compose.yaml (no longer needed in Docker Compose v2+)