### PR TITLE
SUP-50766 Fix locale fallback overwriting language detection

### DIFF
--- a/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
+++ b/netboot-services/ipxeMenuGenerator/menu.ipxe.j2
@@ -5,18 +5,19 @@
 # Language-Detection: Set different languages based on the default gateway IP address
 :language
 # Lausanne
-iseq ${netX/gateway} 172.20.72.1 && set language fr_CH ||
+iseq ${netX/gateway} 172.20.72.1 && set language fr_CH && goto set_protocol ||
 # Genf
-iseq ${netX/gateway} 172.20.56.1 && set language fr_CH ||
+iseq ${netX/gateway} 172.20.56.1 && set language fr_CH && goto set_protocol ||
 # Krefeld
-iseq ${netX/gateway} 172.22.32.1 && set language de_DE ||
+iseq ${netX/gateway} 172.22.32.1 && set language de_DE && goto set_protocol ||
 # Odilia
-iseq ${netX/gateway} 172.22.240.1 && set language de_DE ||
+iseq ${netX/gateway} 172.22.240.1 && set language de_DE && goto set_protocol ||
 # ON1
-iseq ${netX/gateway} 172.22.164.1 && set language de_DE ||
-# Fallback (when no condition above triggers to set next-server)
+iseq ${netX/gateway} 172.22.164.1 && set language de_DE && goto set_protocol ||
+# Fallback
 set language de_CH
 
+:set_protocol
 set http-protocol http && set url ${next-server} && goto macboot
 
 :macboot


### PR DESCRIPTION
## Summary
- #44 removed `goto check_boot_from_azure` from gateway-based locale detection, causing the `de_CH` fallback to always run and overwrite `fr_CH`/`de_DE` locales
- Add `goto set_protocol` on successful gateway match to skip fallback

Fixes https://jiradg.atlassian.net/browse/SUP-50766